### PR TITLE
Do not compare with boolean literal

### DIFF
--- a/jarvis.cabal
+++ b/jarvis.cabal
@@ -18,6 +18,7 @@ library
   exposed-modules:     Jarvis
                        Jarvis.Hint.All
                        Jarvis.Hint.BadCovariantDefinitionOfEquals
+                       Jarvis.Hint.BadComparisonWithBoolean
                        Jarvis.Hint.Type
                        Jarvis.Idea
                        Jarvis.Settings
@@ -49,6 +50,9 @@ test-suite jarvis-test
                      , QuickCheck
                      , language-java >= 0.2.8 && < 0.3
                      , raw-strings-qq
+  other-modules:       Jarvis.Hint.BadComparisonWithBooleanSpec
+                       Jarvis.Hint.BadCovariantDefinitionOfEqualsSpec
+                       Jarvis.Hint.Helper
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/jarvis.cabal
+++ b/jarvis.cabal
@@ -45,6 +45,10 @@ test-suite jarvis-test
   main-is:             Spec.hs
   build-depends:       base
                      , jarvis
+                     , hspec
+                     , QuickCheck
+                     , language-java >= 0.2.8 && < 0.3
+                     , raw-strings-qq
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/src/Jarvis.hs
+++ b/src/Jarvis.hs
@@ -10,8 +10,8 @@ import Data.Foldable
 import Data.Generics.Uniplate.Data
 import Data.List (isSuffixOf)
 import Data.Version (showVersion)
-import Language.Java.Parser
-import Language.Java.Syntax
+import Language.Java.Parser (parser, compilationUnit)
+import Language.Java.Syntax (CompilationUnit(..))
 import System.Directory
 import System.FilePath
 

--- a/src/Jarvis/Hint/All.hs
+++ b/src/Jarvis/Hint/All.hs
@@ -6,14 +6,17 @@ module Jarvis.Hint.All
 
 import Jarvis.Hint.Type
 import Jarvis.Hint.BadCovariantDefinitionOfEquals
+import Jarvis.Hint.BadComparisonWithBoolean
 
 data HintBuiltin =
     HintBadCovariantDefinitionOfEquals
+    | HintBadComparisonWithBoolean
   deriving (Show,Eq,Ord,Bounded,Enum)
 
 builtin :: HintBuiltin -> Hint
 builtin x = case x of
   HintBadCovariantDefinitionOfEquals -> typeDecl badCovariantDefinitionOfEqualsHint
+  HintBadComparisonWithBoolean -> typeDecl badComparisonWithBooleanHint
   where
     typeDecl x = mempty{hintTypeDecl=x}
 

--- a/src/Jarvis/Hint/BadComparisonWithBoolean.hs
+++ b/src/Jarvis/Hint/BadComparisonWithBoolean.hs
@@ -1,0 +1,27 @@
+module Jarvis.Hint.BadComparisonWithBoolean 
+  ( badComparisonWithBooleanHint
+  ) where
+
+import Data.Generics.Uniplate.Data
+import Language.Java.Syntax
+import Jarvis.Hint.Type
+import Jarvis.Idea (suggest, Idea)
+
+fix (BinOp lhs op (Lit (Boolean bool))) = 
+  if (op == Equal) == bool
+  then lhs
+  else (PreNot lhs) -- TODO if lhs is PreNot , normalize
+
+fix (BinOp (Lit (Boolean bool)) op rhs) = 
+  if (op == Equal) == bool
+  then rhs
+  else (PreNot rhs)
+
+idea :: Exp -> Idea
+idea e = suggest "Use boolean as it is or negate it" e (fix e)
+ 
+badComparisonWithBooleanHint :: TypeDeclHint
+badComparisonWithBooleanHint typeDecl = 
+  [idea e| e@(BinOp _ op (Lit (Boolean _))) <- universeBi typeDecl, op == Equal || op == NotEq]
+  ++ [idea e| e@(BinOp (Lit (Boolean _)) op _)<- universeBi typeDecl, op == Equal || op == NotEq]
+  

--- a/src/Jarvis/Hint/Type.hs
+++ b/src/Jarvis/Hint/Type.hs
@@ -22,6 +22,6 @@ data Hint = Hint
   }
 
 instance Monoid Hint where
-    mempty = Hint (const []) (const []) (const [])
+    mempty = Hint mempty mempty mempty
     mappend (Hint x1 x2 x3) (Hint y1 y2 y3) =
-        Hint (\a -> x1 a ++ y1 a) (\a -> x2 a ++ y2 a) (\a -> x3 a ++ y3 a)
+        Hint (x1 <> y1) (x2 <> y2) (x3 <> y3)

--- a/test/Jarvis/Hint/BadComparisonWithBooleanSpec.hs
+++ b/test/Jarvis/Hint/BadComparisonWithBooleanSpec.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE QuasiQuotes
+           , RecordWildCards #-}
+module Jarvis.Hint.BadComparisonWithBooleanSpec where
+
+import Test.Hspec
+import Text.RawString.QQ
+
+import Jarvis.Hint.Helper
+import Jarvis.Hint.BadComparisonWithBoolean
+import Jarvis.Settings
+import Jarvis.Idea
+
+import Data.Maybe
+
+import Language.Java.Syntax 
+
+srcBad = [r|
+class Foo {
+  void foo(boolean b) {
+    if (b == false) {
+    }
+    while (b == true) {
+    }
+    if (false == bar(b)) {
+    }
+  }
+}
+|]
+
+assertTo Idea{..} to = ideaTo `shouldBe` (Just to)
+
+spec :: Spec
+spec = do
+  describe "badComparisonWithBooleanHint" $ do
+    it "suggests with boolean compare" $
+      let ideas = runHint badComparisonWithBooleanHint srcBad
+      in map (fromJust.ideaTo) ideas `shouldBe` ["!b", "b", "!bar(b)"]
+          

--- a/test/Jarvis/Hint/BadCovariantDefinitionOfEqualsSpec.hs
+++ b/test/Jarvis/Hint/BadCovariantDefinitionOfEqualsSpec.hs
@@ -9,6 +9,7 @@ import Language.Java.Syntax (CompilationUnit(..))
 
 import Jarvis.Hint.BadCovariantDefinitionOfEquals
 import Jarvis.Idea
+import Jarvis.Hint.Helper
 
 srcBad :: String
 srcBad = [r|
@@ -29,15 +30,11 @@ class Foo {
 }
 |]
 
-runHint :: String -> [Idea]
-runHint src = let (Right (CompilationUnit _ _ typeDecls)) = parser compilationUnit src
-              in concatMap badCovariantDefinitionOfEqualsHint typeDecls
-
 spec :: Spec
 spec = do
   describe "badCovariantDefinitionOfEqualsHint" $ do
     it "warns with bad definition of equals" $
-      runHint srcBad `shouldSatisfy` (not . null)
+      runHint badCovariantDefinitionOfEqualsHint srcBad `shouldSatisfy` (not . null)
     it "detects nothing with good definition of equals" $
-      runHint srcGood `shouldBe` []
+      runHint badCovariantDefinitionOfEqualsHint srcGood `shouldBe` []
 

--- a/test/Jarvis/Hint/BadCovariantDefinitionOfEqualsSpec.hs
+++ b/test/Jarvis/Hint/BadCovariantDefinitionOfEqualsSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Jarvis.Hint.BadCovariantDefinitionOfEqualsSpec where
+
+import Test.Hspec
+import Text.RawString.QQ
+
+import Language.Java.Parser (parser, compilationUnit)
+import Language.Java.Syntax (CompilationUnit(..))
+
+import Jarvis.Hint.BadCovariantDefinitionOfEquals
+import Jarvis.Idea
+
+srcBad :: String
+srcBad = [r|
+class Foo {
+  public boolean equals(Foo other) {
+    return true;
+  }
+}
+|]
+
+srcGood :: String
+srcGood = [r|
+class Foo {
+  @Override
+  public boolean equals(Object other) {
+    return true;
+  }
+}
+|]
+
+runHint :: String -> [Idea]
+runHint src = let (Right (CompilationUnit _ _ typeDecls)) = parser compilationUnit src
+              in concatMap badCovariantDefinitionOfEqualsHint typeDecls
+
+spec :: Spec
+spec = do
+  describe "badCovariantDefinitionOfEqualsHint" $ do
+    it "warns with bad definition of equals" $
+      runHint srcBad `shouldSatisfy` (not . null)
+    it "detects nothing with good definition of equals" $
+      runHint srcGood `shouldBe` []
+

--- a/test/Jarvis/Hint/Helper.hs
+++ b/test/Jarvis/Hint/Helper.hs
@@ -1,0 +1,12 @@
+module Jarvis.Hint.Helper where
+
+import Language.Java.Syntax 
+import Language.Java.Parser
+  
+import Jarvis.Idea
+import Jarvis.Hint.Type
+
+runHint :: TypeDeclHint -> String -> [Idea]
+runHint hint src =
+  let (Right (CompilationUnit _ _ typeDecls)) = parser compilationUnit src
+  in concatMap hint typeDecls

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,2 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+


### PR DESCRIPTION
Suggests simpler expression if exp is compared with bool literal
For example `bar != false` is equiv to `bar`